### PR TITLE
EE-26903 Changing the ingress name

### DIFF
--- a/kd/pttg-euro-tlr-enquiry-form/ingress.yaml
+++ b/kd/pttg-euro-tlr-enquiry-form/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     stable.k8s.psg.io/kcm.provider: http
     ingress.kubernetes.io/enable-modsecurity: "true"
     ingress.kubernetes.io/enable-owasp-modsecurity-crs: "true"
-  name: pttg-euro-tlr-enquiry-form-ingress-external-govuk
+  name: pttg-euro-tlr-enquiry-form-ingress-external
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
 to pttg-euro-tlr-enquiry-form-ingress-external not pttg-euro-tlr-enquiry-form-ingress-external-govuk 